### PR TITLE
Add EventBinding.cs to the mod_managed Makefile.am

### DIFF
--- a/src/mod/languages/mod_managed/Makefile.am
+++ b/src/mod/languages/mod_managed/Makefile.am
@@ -15,7 +15,7 @@ BUILT_SOURCES=FreeSWITCH.Managed.dll
 CS_SRC=$(MANAGED_SRCDIR)/AssemblyInfo.cs $(MANAGED_SRCDIR)/Extensions.cs $(MANAGED_SRCDIR)/Loader.cs $(MANAGED_SRCDIR)/Log.cs
 CS_SRC+=$(MANAGED_SRCDIR)/ManagedSession.cs $(MANAGED_SRCDIR)/PluginInterfaces.cs
 CS_SRC+=$(MANAGED_SRCDIR)/PluginManager.cs $(MANAGED_SRCDIR)/ScriptPluginManager.cs $(MANAGED_SRCDIR)/ChannelVariables.cs $(MANAGED_SRCDIR)/Util.cs
-CS_SRC+=$(MANAGED_SRCDIR)/swig.cs $(MANAGED_SRCDIR)/XmlSearchBinding.cs
+CS_SRC+=$(MANAGED_SRCDIR)/swig.cs $(MANAGED_SRCDIR)/XmlSearchBinding.cs $(MANAGED_SRCDIR)/EventBinding.cs
 
 freeswitch_managed.o: freeswitch_managed.h freeswitch_managed.cpp
 


### PR DESCRIPTION
This includes the EventBinding type into the FreeSWITCH.Managed.dll that is built by make or the util.sh